### PR TITLE
Fixed error message when bios booting phase

### DIFF
--- a/OC/EFI/OC/config.plist
+++ b/OC/EFI/OC/config.plist
@@ -644,8 +644,6 @@
 			<integer>2147483650</integer>
 			<key>LogModules</key>
 			<string>*</string>
-			<key>SerialInit</key>
-			<false/>
 			<key>SysReport</key>
 			<false/>
 			<key>Target</key>
@@ -1041,7 +1039,7 @@
 			<key>ClearScreenOnModeSwitch</key>
 			<false/>
 			<key>ConsoleMode</key>
-			<string></string>
+			<string>Max</string>
 			<key>DirectGopRendering</key>
 			<false/>
 			<key>ForceResolution</key>
@@ -1059,7 +1057,7 @@
 			<key>ReplaceTabWithSpace</key>
 			<false/>
 			<key>Resolution</key>
-			<string>Max</string>
+			<string>3840×2160</string>
 			<key>SanitiseClearScreen</key>
 			<false/>
 			<key>TextRenderer</key>
@@ -1067,7 +1065,7 @@
 			<key>UgaPassThrough</key>
 			<false/>
 			<key>UIScale</key>
-			<integer>-1</integer>
+			<integer>2</integer>
 		</dict>
 		<key>ProtocolOverrides</key>
 		<dict>

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ The EFI of Asrock Z390 Phantom Gamming ITX for Hackintosh
 
 
 ## Changelog
+_12-May-2022_
+- Fixed error message when BIOS booting phase
+
 _21-Apr-2022_
 - Upgraded OpenCore to version `0.8.0`
 - Upgraded KEXTs


### PR DESCRIPTION
1. Fixed resolution value of UEFI -> Output -> Resolution
2. Updated: 
    1). UEFI -> Output -> Console mode = Max
    2). UEFI -> Output -> UIScale

Issue: #25